### PR TITLE
Bug/saved data

### DIFF
--- a/src/main/java/com/teamofelectrorealism/electrorealism/event/ClientEvents.java
+++ b/src/main/java/com/teamofelectrorealism/electrorealism/event/ClientEvents.java
@@ -36,7 +36,7 @@ public class ClientEvents {
 
         NetworkManager networkManager = ElectroRealism.NETWORK_MANAGER;
 
-        HighlightNetworks.highlightNetwork(networkManager.getNetworksData());
+        HighlightNetworks.highlightNetwork(networkManager.getNetworksDataForClient());
         HighlightNetworks.renderHighlights(poseStack, buffer, partialTick);
     }
 }

--- a/src/main/java/com/teamofelectrorealism/electrorealism/network/Network.java
+++ b/src/main/java/com/teamofelectrorealism/electrorealism/network/Network.java
@@ -1,64 +1,258 @@
 package com.teamofelectrorealism.electrorealism.network;
 
+import com.mojang.logging.LogUtils;
 import com.teamofelectrorealism.electrorealism.ElectroRealism;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.*;
+import org.slf4j.Logger;
 
 import java.util.*;
 
 class Network {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
     private final UUID networkId;
     private boolean isValid;
 
-    private Set<INetworkMember> networkMembers;
+    private Set<INetworkMember> networkMembers; // runtime
+    private Set<BlockPos> memberPositions; // for loading, saving
 
+    private static final String NETWORK_ID_KEY = "networkid";
+    private static final String IS_VALID_KEY = "isvalid";
+    private static final String MEMBERS_TAG_KEY = "memberpos";
+
+    /**
+     * Creates a new, valid Network with a random UUID and no members.
+     */
     Network() {
-        this.networkId = UUID.randomUUID();
-        this.isValid = true;
-
-        this.networkMembers = new HashSet<>();
+        this(UUID.randomUUID(), true, new HashSet<>());
+        LOGGER.debug("Created new Network with ID: {}", this.networkId);
         ElectroRealism.NETWORK_MANAGER.addNetwork(this);
     }
 
-    void setInvalid() {
-        isValid = false;
+    /**
+     * Creates a new Network with the specified properties.
+     *
+     * @param id        The UUID of the network.
+     * @param valid     Whether the network is valid.
+     * @param positions The initial set of member positions.
+     */
+    private Network(UUID id, boolean valid, Set<BlockPos> positions) {
+        this.networkId = id;
+        this.isValid = valid;
+        this.memberPositions = positions != null ? new HashSet<>(positions) : new HashSet<>();
+        this.networkMembers = new HashSet<>();
     }
 
+    /**
+     * Marks this network as invalid.
+     * This will cause it to be removed from the NetworkManager's list of active networks.
+     */
+    void setInvalid() {
+        isValid = false;
+        NetworkManager networkManager = ElectroRealism.NETWORK_MANAGER;
+        if (networkManager != null && networkManager.getSavedData() != null) {
+            networkManager.markDataDirty();
+        }
+    }
+
+    /**
+     * Checks if this network is valid.
+     * @return True if the network is valid, false otherwise.
+     */
     boolean isValid() {
         return isValid;
     }
 
+    /**
+     * Gets the unique ID of this network.
+     * @return The UUID of this network.
+     */
     UUID getNetworkId() {
         return networkId;
     }
 
+    /**
+     * Gets the set of runtime members in this network.
+     * @return A set of INetworkMember instances.
+     */
     Set<INetworkMember> getNetworkMembers() {
         return networkMembers;
     }
 
-//    public CompoundTag write() {
-//        CompoundTag tag = new CompoundTag();
-//
-//        tag.putUUID("network_id", networkId);
-//        tag.putBoolean("isvalid", isValid);
-//
-//        return tag;
-//    }
-//
-//    public static Network read(CompoundTag tag) {
-//        Network network = new Network(tag.getUUID("network_id")); //todo hmgde
-//
-//        network.isValid = tag.getBoolean("isvalid");
-//
-//        return network;
-//    }
+    /**
+     * Gets the set of BlockPos representing the positions of members in this network.
+     * @return A set of BlockPos instances.
+     */
+    Set<BlockPos> getMemberPositions() {
+        return new HashSet<>(memberPositions);
+    }
 
+    /**
+     * Adds a single BlockPos to the set of tracked member positions.
+     * Also ensures the corresponding runtime member is added if it exists.
+     * @param pos The BlockPos of the member to add.
+     */
+    void addMemberPosition(BlockPos pos) {
+        if (pos != null) {
+            this.memberPositions.add(pos);
+        }
+    }
+
+    /**
+     * Used by NetworkManager when a member BE is loaded/validated or explicitly added.
+     * Ensures the member's position is tracked.
+     * @param member The runtime member instance to add.
+     */
+    void addRuntimeMember(INetworkMember member) {
+        if (member != null) {
+            // Add to runtime set
+            this.networkMembers.add(member);
+            // Ensure position is also tracked
+            this.memberPositions.add(member.getPos());
+        }
+    }
+
+    /**
+     * Writes the essential network data (ID, validity, member positions) to an NBT tag.
+     * @return A CompoundTag representing this network.
+     */
+    public CompoundTag writeToNbt() {
+        CompoundTag tag = new CompoundTag();
+        tag.putUUID(NETWORK_ID_KEY, this.networkId);
+        tag.putBoolean(IS_VALID_KEY, this.isValid);
+
+        ListTag membersList = new ListTag();
+        for (BlockPos pos : this.memberPositions) {
+            membersList.add(NbtUtils.writeBlockPos(pos));
+        }
+        LOGGER.trace("  Created membersList with {} entries for Network {}", membersList.size(), networkId);
+        tag.put(MEMBERS_TAG_KEY, membersList);
+        return tag;
+    }
+
+    /**
+     * Reads network data from an NBT tag and creates a Network instance.
+     * <p>
+     * This method reads the network's ID, validity status, and member positions from the provided NBT tag.
+     * It expects the member positions to be stored as a list of integer arrays, where each array represents
+     * a BlockPos with three integers (x, y, z). If the tag does not contain the necessary data or if the
+     * data is in an unexpected format, appropriate error or warning messages are logged.
+     * </p>
+     * <p>
+     * The returned Network instance contains the loaded BlockPos of members,
+     * but the runtime INetworkMember set is initially empty.
+     * @param tag The CompoundTag containing network data.
+     * @return A new Network instance with loaded data.
+     */
+    public static Network readFromNbt(CompoundTag tag) {
+        UUID id = tag.contains(NETWORK_ID_KEY) ? tag.getUUID(NETWORK_ID_KEY) : UUID.randomUUID();
+        boolean valid = tag.getBoolean(IS_VALID_KEY);
+        Set<BlockPos> positions = new HashSet<>();
+
+        //LOGGER.debug("Attempting to read NBT for Network ID: {}", id);
+
+        if (tag.contains(MEMBERS_TAG_KEY)) {
+            Tag listTagBase = tag.get(MEMBERS_TAG_KEY);
+
+            if (listTagBase != null && listTagBase.getId() == Tag.TAG_LIST) {
+                ListTag membersList = (ListTag) listTagBase;
+                byte elementType = membersList.getElementType();
+                int listSize = membersList.size();
+                //LOGGER.debug("Network {}: Found '{}' list via generic get(). Actual Size: {}, Element Type ID: {}", id, MEMBERS_TAG_KEY, listSize, elementType);
+
+                if (listSize > 0) {
+                    if (elementType == Tag.TAG_INT_ARRAY) {
+                        for (int i = 0; i < listSize; i++) {
+                            Tag elementTag = membersList.get(i);
+                            if(elementTag instanceof IntArrayTag intArrayTag) {
+                                int[] array = intArrayTag.getAsIntArray();
+                                if (array.length == 3) { // Check for X, Y, Z
+                                    BlockPos pos = new BlockPos(array[0], array[1], array[2]);
+                                    positions.add(pos);
+                                    //LOGGER.trace("    Read BlockPos from Int_Array: {}", pos.toShortString());
+                                } else {
+                                    LOGGER.error("    Int_Array tag at index {} did not have length 3! Length: {}. Cannot create BlockPos.", i, array.length);
+                                }
+                            } else {
+                                LOGGER.error("    Tag at index {} reported Type ID 11 but was not an instance of IntArrayTag!", i);
+                            }
+                        }
+                    } else {
+                        LOGGER.error("  >> ERROR: '{}' list contains unsupported element type ID {}. Cannot load positions.", MEMBERS_TAG_KEY, elementType);
+                    }
+                } else {
+                    LOGGER.debug("  List is empty. No positions to load.");
+                }
+
+            } else if (listTagBase != null) {
+                LOGGER.error("Network {}: Tag '{}' exists but is not a ListTag! Type ID: {}. Cannot load positions.",
+                        id, MEMBERS_TAG_KEY, listTagBase.getId());
+            } else {
+                LOGGER.warn("Network {}: tag.get('{}') returned null?", id, MEMBERS_TAG_KEY);
+            }
+        } else {
+            LOGGER.warn("NBT tag for network {} did not contain member positions list key '{}'", id, MEMBERS_TAG_KEY);
+        }
+
+        //LOGGER.debug("Finished reading NBT for network {}. Valid: {}, Final Positions Count: {}", id, valid, positions.size());
+        return new Network(id, valid, positions);
+    }
+
+    /**
+     * Called every tick to update the network.
+     * Currently does nothing, but will eventually contain network simulation logic.
+     */
     void tick() {
+        // Network simulation logic goes here, soon™
     }
 
-    void registerINetworkMember(INetworkMember networkMember) {
-        networkMembers.add(networkMember);
+    /**
+     * Merges the members from another network into this network.
+     *
+     * @param otherNetwork The network to merge members from.
+     */
+    void mergeMembersFrom(Network otherNetwork) {
+        if (otherNetwork == null) return;
+
+        Set<INetworkMember> otherRuntimeMembers = otherNetwork.getNetworkMembers();
+        Set<BlockPos> otherMemberPositions = otherNetwork.getMemberPositions();
+
+        this.networkMembers.addAll(otherRuntimeMembers);
+        this.memberPositions.addAll(otherMemberPositions);
+
+        UUID targetNetworkId = this.getNetworkId();
+        for (INetworkMember member : otherRuntimeMembers) {
+            member.setNetworkId(targetNetworkId);
+        }
+
+        NetworkManager networkManager = ElectroRealism.NETWORK_MANAGER;
+        if (networkManager != null && networkManager.getSavedData() != null) {
+            networkManager.markDataDirty();
+        }
     }
 
-    void registerAllINetworkMembers(Set<INetworkMember> networkMembers) {
-        this.networkMembers.addAll(networkMembers);
+    /**
+     * Checks if this network is equal to another object.
+     * Two networks are considered equal if they have the same network ID.
+     * @param object The object to compare to.
+     * @return True if the objects are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        Network network = (Network) object;
+        return networkId.equals(network.networkId);
+    }
+
+    /**
+     * Gets the hash code of this network.
+     * The hash code is based on the network ID.
+     * @return The hash code of this network.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(networkId);
     }
 }

--- a/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkManager.java
+++ b/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkManager.java
@@ -1,153 +1,441 @@
 package com.teamofelectrorealism.electrorealism.network;
 
 import com.mojang.logging.LogUtils;
-import com.teamofelectrorealism.electrorealism.rendering.HighlightNetworks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
- * All network creations and connection should be made trough this class
+ * Manages the creation, loading, saving, and merging of electrical networks.
  */
 public class NetworkManager {
     private static final Logger LOGGER = LogUtils.getLogger();
+
     private Set<Network> networks;
-    private NetworkSavedData savedData;
+    @Nullable
+    private NetworkSavedData savedData = null;
+    @Nullable
+    private MinecraftServer server = null;
 
+    /**
+     * Constructs a new NetworkManager.
+     */
     public NetworkManager() {
-        networks = new HashSet<>();
     }
 
-    public void getNetworkIds() {
-        LOGGER.info("List all networks:");
-        for (Network network : networks) {
-            LOGGER.info("UUID: {}, Object: {}", network.getNetworkId(), network);
-        }
-    }
+    // --- Loading and Saving ---
 
+    /**
+     * Called when a level (specifically the Overworld for global data) loads.
+     * Initializes or loads the network data from storage.
+     * @param level The level that loaded (should be the Overworld).
+     */
     public void levelLoaded(LevelAccessor level) {
-        MinecraftServer server = level.getServer();
-        if (server == null || server.overworld() != level) return;
-        
-        networks = new HashSet<>();
-        savedData = null;
-        loadNetworkData(server);
-    }
+        if (!(level instanceof ServerLevel serverLevel) || serverLevel.getServer() == null) {
+            LOGGER.warn("NetworkManager levelLoaded called with non-ServerLevel or null server.");
+            return;
+        }
+        if (this.server != null && this.server == serverLevel.getServer() && this.savedData != null) {
+            LOGGER.debug("NetworkManager already initialized for this server instance.");
+            return;
+        }
 
-    private void loadNetworkData(MinecraftServer server) {
-        if (savedData != null) return;
-        savedData = NetworkSavedData.load(server);
-        networks = savedData.getNetworks();
-    }
+        this.server = serverLevel.getServer();
+        LOGGER.info("NetworkManager initializing for server...");
 
-    public void addNetwork(Network network) {
-        networks.add(network);
-    }
-
-    public void tick() {
-        for (Network network : networks) {
-            network.tick();
+        if (serverLevel == this.server.overworld()) {
+            loadNetworkData(this.server);
+            resolveLoadedMembers(serverLevel);
+        } else {
+            LOGGER.debug("NetworkManager levelLoaded called for non-Overworld dimension, skipping load.");
         }
     }
 
+    /**
+     * Loads network data from the NetworkSavedData instance.
+     * Populates the runtime 'networks' set.
+     * @param server The MinecraftServer instance.
+     */
+    private void loadNetworkData(MinecraftServer server) {
+        if (this.savedData != null) {
+            LOGGER.warn("Attempting to load network data when savedData is already loaded.");
+            return;
+        }
+        try {
+            this.savedData = NetworkSavedData.load(server);
+            this.networks = this.savedData.getNetworks();
+            LOGGER.info("NetworkManager loaded {} networks from NetworkSavedData.", this.networks.size());
+        } catch (Exception e) {
+            LOGGER.error("Failed to load NetworkSavedData!", e);
+            this.networks = new HashSet<>();
+            this.savedData = null;
+        }
+    }
+
+    /**
+     * Attempts to resolve the loaded BlockPos members into runtime INetworkMember instances.
+     * This should be called after loadNetworkData.
+     * IMPORTANT: This basic version assumes chunks are loaded. A robust implementation
+     * might need to integrate with chunk load events or retry resolution.
+     * @param level The ServerLevel (usually Overworld) to check for BlockEntities.
+     */
+    private void resolveLoadedMembers(ServerLevel level) {
+        if (this.networks.isEmpty()) {
+            LOGGER.info("No networks loaded, skipping member resolution.");
+            return;
+        }
+        LOGGER.info("Attempting to resolve BlockPos to INetworkMember for loaded networks...");
+        int resolvedCount = 0;
+        int totalPositions = 0;
+
+        for (Network network : this.networks) {
+            Set<BlockPos> positions = network.getMemberPositions();
+            totalPositions += positions.size();
+            for (BlockPos pos : positions) {
+                if (level.isLoaded(pos)) {
+                    BlockEntity blockEntity = level.getBlockEntity(pos);
+                    if (blockEntity instanceof INetworkMember member) {
+                        UUID memberNetworkId = member.getNetworkId();
+                        if (memberNetworkId == null || memberNetworkId.equals(network.getNetworkId())) {
+                            if (memberNetworkId == null) {
+                                member.setNetworkId(network.getNetworkId());
+                            }
+                            network.addRuntimeMember(member);
+                            resolvedCount++;
+                        } else {
+                            LOGGER.warn("INetworkMember at {} reports network {} but loaded data expects network {}. This might indicate stale data or merge issues.",
+                                    pos, memberNetworkId, network.getNetworkId());
+                            // Decide how to handle: remove from this network's positions? Force update BE? Log only?
+                        }
+                    } else {
+                        LOGGER.debug("No valid INetworkMember found at loaded position {}. Block might have been removed.", pos);
+                        // Consider removing 'pos' from network.getMemberPositions() here
+                    }
+                } else {
+                    LOGGER.trace("Chunk not loaded at {}, skipping member resolution for now.", pos);
+                    // Need chunk loading integration for full robustness
+                }
+            }
+        }
+        LOGGER.info("Finished member resolution attempt. Resolved {} out of {} total positions.", resolvedCount, totalPositions);
+    }
+
+    /**
+     * Marks the NetworkSavedData as dirty, triggering a save on the next world save event.
+     */
+    public void markDataDirty() {
+        if (this.savedData != null) {
+            this.savedData.updateNetworkData(this.networks);
+            LOGGER.debug("Notified NetworkSavedData to check for updates.");
+        } else {
+            LOGGER.warn("Attempted to mark data dirty, but NetworkSavedData instance is null.");
+        }
+    }
+
+    // --- Network Management ---
+
+    /**
+     * Adds a network to the manager's runtime set.
+     * Should be called by the Network constructor.
+     * @param network The network to add.
+     */
+    void addNetwork(Network network) {
+        if (network != null) {
+            boolean added = networks.add(network);
+            if(added) {
+                LOGGER.debug("Added Network {} to NetworkManager.", network.getNetworkId());
+                markDataDirty();
+            }
+        }
+    }
+
+    /**
+     * Creates a new Network instance. The Network constructor handles adding itself
+     * to the manager via `addNetwork`.
+     * @return The UUID of the newly created network.
+     * @see Network#Network()
+     */
     public UUID createNetwork() {
         Network network = new Network();
-        LOGGER.info("New network with UUID: {}", network.getNetworkId());
+        LOGGER.info("Initiated creation of new network with UUID: {}", network.getNetworkId());
         return network.getNetworkId();
     }
 
+    /**
+     * Registers a runtime INetworkMember instance with its corresponding Network.
+     * Should be called when a member BlockEntity is loaded or placed.
+     * @param networkId The ID of the network the member belongs to.
+     * @param networkMember The member instance.
+     * @see INetworkMember
+     */
     public void registerINetworkMemberInNetwork(UUID networkId, INetworkMember networkMember) {
         Network network = findNetwork(networkId);
-        if (network != null) network.registerINetworkMember(networkMember);
-    }
-
-    private Network findNetwork(UUID networkId) {
-        for (Network network : networks) {
-            if (network.getNetworkId() == networkId) return network;
+        if (network != null && networkMember != null) {
+            network.addRuntimeMember(networkMember);
+            LOGGER.debug("Registered runtime member at {} to network {}", networkMember.getPos(), networkId);
+        } else if (networkMember != null) {
+            LOGGER.warn("Attempted to register member at {} to non-existent network {}", networkMember.getPos(), networkId);
         }
-        return null;
     }
 
+    /**
+     * Finds a Network instance by its UUID in the runtime set.
+     * @param networkId The UUID to search for.
+     * @return The found Network, or null if not found.
+     * @see Network
+     */
+    @Nullable
+    private Network findNetwork(UUID networkId) {
+        if (networkId == null) return null;
+        return networks.stream()
+                .filter(n -> n.getNetworkId().equals(networkId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Determines the correct network ID when connecting two members, creating or merging networks as needed.
+     * @param networkMember1 First member being connected.
+     * @param networkMember2 Second member being connected.
+     * @return The UUID of the resulting network.
+     * @see INetworkMember
+     */
     public UUID createOrMergeNetworks(INetworkMember networkMember1, INetworkMember networkMember2) {
         UUID networkId1 = networkMember1.getNetworkId();
         UUID networkId2 = networkMember2.getNetworkId();
+        UUID resultingNetworkId;
 
         if (networkId1 == null && networkId2 == null) {
-            // Neither node has a network, create a new one
-            return createNetwork();
-        } else if (networkId1 != null && networkId2 == null) {
-            // Only node1 has a network, use it
-            LOGGER.info("Using network with UUID: {}", networkId1);
-            return networkId1;
-        } else if (networkId1 == null && networkId2 != null) {
-            // Only node2 has a network, use it
-            LOGGER.info("Using network with UUID: {}", networkId2);
-            return networkId2;
-        } else {
-            // Both nodes have networks, merge them into network1
-            if (networkId1.equals(networkId2)) {
-                LOGGER.info("Using network with UUID: {}", networkId1);
-                return networkId1;
+            resultingNetworkId = createNetwork();
+            LOGGER.info("Connecting two members with no existing networks. Created new network: {}", resultingNetworkId);
+
+            Network newNetwork = findNetwork(resultingNetworkId);
+            if (newNetwork != null) {
+                LOGGER.debug("Adding initial members ({}, {}) to new network {}",
+                        networkMember1.getPos().toShortString(),
+                        networkMember2.getPos().toShortString(),
+                        resultingNetworkId);
+
+                newNetwork.addMemberPosition(networkMember1.getPos());
+                newNetwork.addMemberPosition(networkMember2.getPos());
+
+                newNetwork.addRuntimeMember(networkMember1);
+                newNetwork.addRuntimeMember(networkMember2);
+
+                markDataDirty();
+            } else {
+                LOGGER.error("Newly created network {} could not be found immediately!", resultingNetworkId);
             }
-            return mergeNetworks(networkId1, networkId2);
+
+        } else if (networkId1 != null && networkId2 == null) {
+            resultingNetworkId = networkId1;
+            LOGGER.info("Connecting member {} without network to existing network: {}", networkMember2.getPos().toShortString(), resultingNetworkId);
+            Network network1 = findNetwork(networkId1);
+            if (network1 != null) {
+                network1.addRuntimeMember(networkMember2);
+                markDataDirty();
+            } else {
+                LOGGER.error("Network {} not found during connection, but member {} reported it!", networkId1, networkMember1.getPos());
+            }
+        } else if (networkId1 == null && networkId2 != null) {
+            // Only node2 has a network, use it (Symmetrical to above)
+            resultingNetworkId = networkId2;
+            LOGGER.info("Connecting member {} without network to existing network: {}", networkMember1.getPos().toShortString(), resultingNetworkId);
+            Network network2 = findNetwork(networkId2);
+            if (network2 != null) {
+                network2.addRuntimeMember(networkMember1);
+                markDataDirty();
+            } else {
+                LOGGER.error("Network {} not found during connection, but member {} reported it!", networkId2, networkMember2.getPos());
+            }
+        } else {
+            if (networkId1.equals(networkId2)) {
+                resultingNetworkId = networkId1;
+                LOGGER.debug("Connecting two members already in the same network: {}", resultingNetworkId);
+                Network network = findNetwork(resultingNetworkId);
+                if (network != null) {
+                    network.addRuntimeMember(networkMember1);
+                    network.addRuntimeMember(networkMember2);
+                }
+            } else {
+                LOGGER.info("Connecting members from different networks ({} and {}). Merging...", networkId1, networkId2);
+                resultingNetworkId = mergeNetworks(networkId1, networkId2);
+            }
         }
+
+        if (resultingNetworkId != null) {
+            if (!resultingNetworkId.equals(networkMember1.getNetworkId())) {
+                networkMember1.setNetworkId(resultingNetworkId);
+            }
+            if (!resultingNetworkId.equals(networkMember2.getNetworkId())) {
+                networkMember2.setNetworkId(resultingNetworkId);
+            }
+        } else {
+            LOGGER.error("Resulting network ID was null after createOrMerge! Member1: {}, Member2: {}", networkMember1.getPos().toShortString(), networkMember2.getPos().toShortString());
+        }
+
+        return resultingNetworkId;
     }
 
+    /**
+     * Merges network2 into network1. Network1 becomes the dominant network.
+     * Updates member IDs and marks data as dirty.
+     * @param networkId1 The ID of the network to merge into.
+     * @param networkId2 The ID of the network to be merged and removed.
+     * @return The UUID of the merged network (networkId1).
+     * @see Network
+     */
     private UUID mergeNetworks(UUID networkId1, UUID networkId2) {
         Network network1 = findNetwork(networkId1);
         Network network2 = findNetwork(networkId2);
-        UUID networkId;
 
-        if (network1 != null && network2 != null) {
-            // Merge network2 into network1
-            network1.registerAllINetworkMembers(network2.getNetworkMembers());
-            network2.setInvalid();
-            networks.remove(network2);
-            LOGGER.info("Merged network {} into {}", networkId2, networkId1);
-            networkId = networkId1;
+        if (network1 == null && network2 == null) {
+            LOGGER.error("Attempted to merge two non-existent networks: {} and {}", networkId1, networkId2);
+            return createNetwork();
         } else if (network1 == null) {
-            LOGGER.error("Network1 not found, but should exist");
-            networkId = networkId2;
-        } else {
-            LOGGER.error("Network2 not found, but should exist");
-            networkId = networkId1;
+            LOGGER.warn("Network {} to merge into not found. Using Network {} as primary.", networkId1, networkId2);
+            markDataDirty();
+            return networkId2;
+        } else if (network2 == null) {
+            LOGGER.warn("Network {} to be merged not found. Keeping Network {} as is.", networkId2, networkId1);
+            markDataDirty();
+            return networkId1;
         }
 
-        updateNetworkIds(networkId, findNetwork(networkId).getNetworkMembers());
-        return networkId;
+        LOGGER.info("Merging Network {} into Network {}", networkId2, networkId1);
+        network1.mergeMembersFrom(network2);
+        network2.setInvalid();
+        networks.remove(network2);
+
+        updateNetworkIdsOnBlockEntities(networkId1, network2.getMemberPositions());
+
+        markDataDirty();
+        return networkId1;
     }
 
-    private void updateNetworkIds(UUID networkId, Set<INetworkMember> networkMembers) {
-        for (INetworkMember networkMember : networkMembers) {
-            networkMember.setNetworkId(networkId);
+    /**
+     * Helper to update the networkId field on BlockEntities at given positions.
+     * Requires access to the level.
+     * @param networkId The new network ID to set.
+     * @param memberPositions Positions of members whose ID needs updating.
+     * @see INetworkMember
+     */
+    private void updateNetworkIdsOnBlockEntities(UUID networkId, Set<BlockPos> memberPositions) {
+        if (server == null) {
+            LOGGER.error("Cannot update BE network IDs: Server instance is null.");
+            return;
+        }
+        ServerLevel level = server.overworld();
+        if (level == null) {
+            LOGGER.error("Cannot update BE network IDs: Overworld instance is null.");
+            return;
+        }
+
+        for (BlockPos pos : memberPositions) {
+            if (level.isLoaded(pos)) {
+                BlockEntity be = level.getBlockEntity(pos);
+                if (be instanceof INetworkMember member) {
+                    if (!networkId.equals(member.getNetworkId())) {
+                        member.setNetworkId(networkId);
+                        LOGGER.debug("Updated Network ID for member at {} to {}", pos, networkId);
+                    }
+                }
+            } else {
+                LOGGER.trace("Cannot update BE Network ID at {}: Chunk not loaded.", pos);
+            }
         }
     }
 
+    // --- Ticking ---
+
+    /**
+     * Ticks all valid networks. Called from a server tick event handler.
+     * @see Network#tick()
+     */
+    public void tick() {
+        if (networks.isEmpty()) return;
+        for (Network network : networks) {
+            if (network.isValid()) {
+                network.tick();
+            }
+        }
+    }
+
+    // --- Utility and Debug
+
+    /**
+     * Prints the IDs of all currently managed networks to the log.
+     * @see Network#getNetworkId()
+     */
+    public void getNetworkIds() {
+        LOGGER.info("Listing all managed networks ({} total):", networks.size());
+        for (Network network : networks) {
+            LOGGER.info("  - UUID: {}, Valid: {}, Runtime Members: {}, Saved Positions: {}",
+                    network.getNetworkId(),
+                    network.isValid(),
+                    network.getNetworkMembers().size(),
+                    network.getMemberPositions().size()
+            );
+        }
+    }
+
+    /**
+     * Prints details of members within a specific network.
+     * @param networkId The UUID of the network to inspect.
+     * @see Network
+     */
     public void printMembersInNetwork(UUID networkId) {
         Network network = findNetwork(networkId);
-        Set<INetworkMember> networkMembers = network.getNetworkMembers();
-        if (networkMembers == null) return;
-        LOGGER.info("All members in clicked network with UUID: {}", networkId);
-        for (INetworkMember networkMember : networkMembers) {
-            LOGGER.info("Member: {}", networkMember);
+        if (network == null) {
+            LOGGER.info("Network with UUID {} not found.", networkId);
+            return;
         }
+
+        Set<INetworkMember> runtimeMembers = network.getNetworkMembers();
+        Set<BlockPos> savedPositions = network.getMemberPositions();
+
+        LOGGER.info("Details for Network UUID: {}", networkId);
+        LOGGER.info("  Saved Positions ({}):", savedPositions.size());
+        savedPositions.forEach(pos -> LOGGER.info("    - {}", pos.toShortString()));
+
+        LOGGER.info("  Runtime Members ({}):", runtimeMembers.size());
+        if (runtimeMembers.isEmpty() && !savedPositions.isEmpty()) {
+            LOGGER.info("    (Runtime members may not be loaded yet)");
+        }
+        runtimeMembers.forEach(member -> LOGGER.info("    - BE at {}", member.getPos().toShortString()));
     }
 
-    public Map<UUID, List<BlockPos>> getNetworksData() {
+    /**
+     * Gets the network data formatted for client-side highlighting.
+     * @see Network
+     * @return Map of Network UUID to List of member BlockPos.
+     */
+    public Map<UUID, List<BlockPos>> getNetworksDataForClient() {
         Map<UUID, List<BlockPos>> data = new HashMap<>();
         for (Network network : networks) {
             if (network.isValid()) {
-                List<BlockPos> blockPositions = network.getNetworkMembers().stream()
-                        .map(INetworkMember::getPos)
-                        .collect(Collectors.toList());
-                data.put(network.getNetworkId(), blockPositions);
+                List<BlockPos> blockPositions = new ArrayList<>(network.getMemberPositions());
+                if (!blockPositions.isEmpty()) {
+                    data.put(network.getNetworkId(), blockPositions);
+                }
             }
         }
         return data;
     }
 
+    /**
+     * Provides access to the SavedData instance
+     * @return The NetworkSavedData instance, or null if not loaded.
+     * @see NetworkSavedData
+     */
+    @Nullable
+    public NetworkSavedData getSavedData() {
+        return savedData;
+    }
 }

--- a/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkSavedData.java
+++ b/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkSavedData.java
@@ -1,67 +1,183 @@
 package com.teamofelectrorealism.electrorealism.network;
 
+import com.mojang.logging.LogUtils;
 import com.teamofelectrorealism.electrorealism.ElectroRealism;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.saveddata.SavedData;
+import org.slf4j.Logger;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
-// https://docs.neoforged.net/docs/1.21.1/datastorage/saveddata
+/**
+ * Manages the persistent storage of {@link Network} data across server restarts.
+ * This class extends {@link SavedData} to handle the loading and saving of network
+ * information to and from NBT data. It ensures that network configurations are
+ * preserved between game sessions.
+ *
+ * @see SavedData
+ * @see Network
+ * @see <a href="https://docs.neoforged.net/docs/1.21.1/datastorage/saveddata">NeoForge SavedData Documentation</a>
+ */
 public class NetworkSavedData extends SavedData {
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     private Set<Network> networks = new HashSet<>();
 
-    public NetworkSavedData() {
-    }
+    private static final String NETWORKS_LIST_KEY = "networks";
+    /**
+     * Private constructor to prevent direct instantiation.
+     */
+    private NetworkSavedData() {}
 
+    /**
+     * Factory for creating and loading {@link NetworkSavedData} instances.
+     */
     public static final SavedData.Factory<NetworkSavedData> FACTORY = new SavedData.Factory<>(
             NetworkSavedData::create,
-            NetworkSavedData::load,
+            NetworkSavedData::LoadFromNbt,
             null);
 
-    // Create new instance of saved data
+    /**
+     * Creates a new instance of {@link NetworkSavedData}.
+     *
+     * @return A new {@link NetworkSavedData} instance.
+     */
     public static NetworkSavedData create() {
+        LOGGER.info("Creating new NetworkSavedData instance.");
         return new NetworkSavedData();
     }
 
-    // Load existing instance of saved data
+    /**
+     * Loads or creates the {@link NetworkSavedData} instance for the Overworld.
+     * If the data does not exist, it creates a new instance.
+     *
+     * @param server The {@link MinecraftServer} instance.
+     * @return The loaded or newly created {@link NetworkSavedData} instance.
+     */
     public static NetworkSavedData load(MinecraftServer server) {
+        LOGGER.info("Attempting to load or create NetworkSavedData for Overworld.");
         return server.overworld()
                 .getDataStorage()
                 .computeIfAbsent(FACTORY, ElectroRealism.MODID + "_networks");
     }
 
-    private static NetworkSavedData load(CompoundTag tag, HolderLookup.Provider provider) {
+    /**
+     * Loads {@link NetworkSavedData} from NBT data. This method is called by the {@link SavedData.Factory}
+     * when loading data from disk. It reads the list of networks from the NBT tag and reconstructs
+     * the {@link NetworkSavedData} instance.
+     *
+     * @param tag      The {@link CompoundTag} containing the saved data.
+     * @param provider The {@link HolderLookup.Provider} for resource lookups.
+     * @return A {@link NetworkSavedData} instance loaded from the NBT data.
+     * @Logs: Exception If there is an error loading a network from the NBT data.
+     */
+    private static NetworkSavedData LoadFromNbt(CompoundTag tag, HolderLookup.Provider provider) {
+        LOGGER.info("Loading NetworkSavedData from NBT.");
         NetworkSavedData savedData = new NetworkSavedData();
-        ListTag networkList = tag.getList("Networks", Tag.TAG_COMPOUND);
-//        networkList.forEach(networkTag -> {
-//            savedData.networks.add(Network.read((CompoundTag) networkTag));
-//        });
+        Set<Network> loadedNetworks = new HashSet<>();
+
+        if (tag.contains(NETWORKS_LIST_KEY, Tag.TAG_LIST)) {
+            ListTag networkList = tag.getList(NETWORKS_LIST_KEY, Tag.TAG_COMPOUND);
+            LOGGER.info("Found {} networks in NBT list.", networkList.size());
+
+            for (Tag networkTagGeneric : networkList) {
+                if (networkTagGeneric instanceof CompoundTag networkTag) {
+                    try {
+                        Network loadedNetwork = Network.readFromNbt(networkTag);
+                        if (loadedNetwork.isValid()) {
+                            loadedNetworks.add(loadedNetwork);
+                            LOGGER.debug("Successfully loaded Network {}", loadedNetwork.getNetworkId());
+                        } else {
+                            LOGGER.debug("Skipping loading invalid Network {}", loadedNetwork.getNetworkId());
+                        }
+                    } catch (Exception e) {
+                        LOGGER.error("Failed to load a Network from NBT tag: {}", networkTag, e);
+                    }
+                } else {
+                    LOGGER.warn("Unexpected tag type in Networks list: {}", networkTagGeneric.getType().getName());
+                }
+            }
+        } else {
+            LOGGER.info("No '{}' list tag found in NBT.", NETWORKS_LIST_KEY);
+        }
+
+        savedData.networks = loadedNetworks;
+        LOGGER.info("Finished loading NetworkSavedData. {} valid networks loaded.", loadedNetworks.size());
         return savedData;
     }
 
+    /**
+     * Saves the current {@link Network} data to NBT.
+     *
+     * @param tag      The {@link CompoundTag} to save the data to.
+     * @param provider The {@link HolderLookup.Provider} for resource lookups.
+     * @return The {@link CompoundTag} with the saved data.
+     * @throws Exception If there is an error writing a network to the NBT data.
+     */
     @Override
     public CompoundTag save(CompoundTag tag, HolderLookup.Provider provider) {
-        NetworkManager networkManager = ElectroRealism.NETWORK_MANAGER;
-        tag.put("Networks", new CompoundTag());
+        LOGGER.info("Saving NetworkSavedData to NBT. Saving {} networks.", this.networks.size());
+        ListTag networksList = new ListTag();
+
+        for (Network network : this.networks) {
+            if (network != null) {
+                try {
+                    networksList.add(network.writeToNbt());
+                    LOGGER.trace("Saved Network {} to NBT list.", network.getNetworkId());
+                } catch (Exception e) {
+                    LOGGER.error("Failed to write Network {} to NBT.", network.getNetworkId(), e);
+                }
+            } else {
+                LOGGER.warn("Attempted to save a null Network instance.");
+            }
+        }
+
+        tag.put(NETWORKS_LIST_KEY, networksList);
+        LOGGER.info("Finished saving NetworkSavedData.");
         return tag;
     }
 
-    public void onNetworkChanged() {
-        // Change data in saved data
-        // Call set dirty if data changes
-        this.setDirty();
+    /**
+     * Updates the network data with the current networks from the {@link NetworkManager}.
+     * Marks the data as dirty if changes are detected.
+     *
+     * @param currentNetworksFromManager The current set of {@link Network} from the manager.
+     */
+    public void updateNetworkData(Set<Network> currentNetworksFromManager) {
+        // Log the state *before* comparison
+        int currentInternalSize = this.networks.size();
+        int incomingSize = currentNetworksFromManager.size();
+        LOGGER.debug("updateNetworkData called. Internal size: {}, Incoming size: {}", currentInternalSize, incomingSize);
+        // Optional: Log details of incoming networks' member counts
+        // currentNetworksFromManager.forEach(n -> LOGGER.trace("  Incoming Network {} has {} positions.", n.getNetworkId(), n.getMemberPositions().size()));
+
+
+        // Compare based on the Set's equals method (relies on Network.equals/hashCode)
+        if (!this.networks.equals(currentNetworksFromManager)) {
+            // Log the counts of the internal set being replaced
+            // this.networks.forEach(n -> LOGGER.trace("  Old Internal Network {} had {} positions.", n.getNetworkId(), n.getMemberPositions().size()));
+
+            // Create a new set from the manager's data
+            this.networks = new HashSet<>(currentNetworksFromManager);
+            LOGGER.info("Network data CHANGED. Updating internal set (new size: {}) and marking dirty.", this.networks.size());
+            // Log the counts of the *new* internal set
+            // this.networks.forEach(n -> LOGGER.trace("  New Internal Network {} has {} positions.", n.getNetworkId(), n.getMemberPositions().size()));
+            setDirty(true); // Explicitly set dirty
+        } else {
+            LOGGER.debug("Network data appears unchanged, not marking as dirty.");
+        }
     }
 
-    public Set<Network> getNetworks() {
-        return networks;
+    /**
+     * Gets a copy of the current set of networks.
+     *
+     * @return A new {@link Set} containing the current {@link Network} instances.
+     */
+    Set<Network> getNetworks() {
+        return new HashSet<>(this.networks);
     }
 }

--- a/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkSavedData.java
+++ b/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkSavedData.java
@@ -38,7 +38,7 @@ public class NetworkSavedData extends SavedData {
      */
     public static final SavedData.Factory<NetworkSavedData> FACTORY = new SavedData.Factory<>(
             NetworkSavedData::create,
-            NetworkSavedData::LoadFromNbt,
+            NetworkSavedData::loadFromNbt,
             null);
 
     /**
@@ -75,7 +75,7 @@ public class NetworkSavedData extends SavedData {
      * @return A {@link NetworkSavedData} instance loaded from the NBT data.
      * @Logs: Exception If there is an error loading a network from the NBT data.
      */
-    private static NetworkSavedData LoadFromNbt(CompoundTag tag, HolderLookup.Provider provider) {
+    private static NetworkSavedData loadFromNbt(CompoundTag tag, HolderLookup.Provider provider) {
         LOGGER.info("Loading NetworkSavedData from NBT.");
         NetworkSavedData savedData = new NetworkSavedData();
         Set<Network> loadedNetworks = new HashSet<>();

--- a/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkSavedData.java
+++ b/src/main/java/com/teamofelectrorealism/electrorealism/network/NetworkSavedData.java
@@ -148,25 +148,15 @@ public class NetworkSavedData extends SavedData {
      * @param currentNetworksFromManager The current set of {@link Network} from the manager.
      */
     public void updateNetworkData(Set<Network> currentNetworksFromManager) {
-        // Log the state *before* comparison
         int currentInternalSize = this.networks.size();
         int incomingSize = currentNetworksFromManager.size();
         LOGGER.debug("updateNetworkData called. Internal size: {}, Incoming size: {}", currentInternalSize, incomingSize);
-        // Optional: Log details of incoming networks' member counts
-        // currentNetworksFromManager.forEach(n -> LOGGER.trace("  Incoming Network {} has {} positions.", n.getNetworkId(), n.getMemberPositions().size()));
 
 
-        // Compare based on the Set's equals method (relies on Network.equals/hashCode)
         if (!this.networks.equals(currentNetworksFromManager)) {
-            // Log the counts of the internal set being replaced
-            // this.networks.forEach(n -> LOGGER.trace("  Old Internal Network {} had {} positions.", n.getNetworkId(), n.getMemberPositions().size()));
-
-            // Create a new set from the manager's data
             this.networks = new HashSet<>(currentNetworksFromManager);
             LOGGER.info("Network data CHANGED. Updating internal set (new size: {}) and marking dirty.", this.networks.size());
-            // Log the counts of the *new* internal set
-            // this.networks.forEach(n -> LOGGER.trace("  New Internal Network {} has {} positions.", n.getNetworkId(), n.getMemberPositions().size()));
-            setDirty(true); // Explicitly set dirty
+            setDirty();
         } else {
             LOGGER.debug("Network data appears unchanged, not marking as dirty.");
         }


### PR DESCRIPTION
Implements persistence for electrical networks using NeoForge's SavedData system. Network state, including ID and member positions, is now saved to `electrorealism_networks.dat` in the world's data folder.

Added Javadocs to `NetworkManager`, `Network` and `NetworkSavedData`.

Refactors `Network` to include `writeToNbt` and `readFromNbt` methods. Updates `NetworkSavedData` to manage saving/loading lists of `Network` NBT. Modifies `NetworkManager` to interact with `NetworkSavedData`, handle loading, member resolution, and trigger saves via `setDirty`.

fix: Correct network data loading after game restart

Resolves an issue where network member positions were lost after completely restarting the game, despite being present in the saved file.

The root cause was identified as `NbtUtils.writeBlockPos` serializing `BlockPos` as `TAG_Int_Array` (ID 11), while the initial loading code expected `TAG_Compound` (ID 10).

The `Network.readFromNbt` method has been updated to correctly detect and parse `TAG_Int_Array` elements within the member position list, ensuring data loads correctly after restarts. Also corrected previous minor NBT key inconsistencies during debugging.