### PR TITLE
feat: Implement comprehensive machine and connector configuration

### DIFF
--- a/src/main/java/com/teamofpowersim/powersim/Config.java
+++ b/src/main/java/com/teamofpowersim/powersim/Config.java
@@ -1,63 +1,312 @@
 package com.teamofpowersim.powersim;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
-// An example config class. This is not required, but it's a good idea to have one to keep your config organized.
-// Demonstrates how to use Neo's config APIs
 @EventBusSubscriber(modid = PowerSim.MODID, bus = EventBusSubscriber.Bus.MOD)
 public class Config
 {
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
-    private static final ModConfigSpec.BooleanValue LOG_DIRT_BLOCK = BUILDER
-            .comment("Whether to log the dirt block on common setup")
-            .define("logDirtBlock", true);
+    static {
+        BUILDER.comment("Specific operational parameters for the Small Connector")
+                .push("small_connector_specifics");
 
-    private static final ModConfigSpec.IntValue MAGIC_NUMBER = BUILDER
-            .comment("A magic number")
-            .defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
+        SMALL_CONNECTOR_MAX_WIRE_LENGTH = BUILDER
+                .comment("Maximum wire length for Small Connectors.")
+                .defineInRange("small_connector_max_wire_length", 16, 1, 64);
 
-    public static final ModConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION = BUILDER
-            .comment("What you want the introduction message to be for the magic number")
-            .define("magicNumberIntroduction", "The magic number is... ");
+        SMALL_CONNECTOR_CONNECTION_POINT_COUNT = BUILDER
+                .comment("Number of connection points for Small Connectors.")
+                .defineInRange("small_connector_connection_point_count", 4, 1, 8);
 
-    // a list of strings that are treated as resource locations for items
-    private static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS = BUILDER
-            .comment("A list of items to log on common setup.")
-            .defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), Config::validateItemName);
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Large Connector")
+                .push("large_connector_specifics");
+
+        LARGE_CONNECTOR_MAX_WIRE_LENGTH = BUILDER
+                .comment("Maximum wire length for Large Connectors.")
+                .defineInRange("large_connector_max_wire_length", 32, 1, 128);
+
+        LARGE_CONNECTOR_CONNECTION_POINT_COUNT = BUILDER
+                .comment("Number of connection points for Large Connectors.")
+                .defineInRange("large_connector_connection_point_count", 6, 1, 12);
+
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Duo Connector")
+                .push("duo_connector_specifics");
+
+        DUO_CONNECTOR_MAX_WIRE_LENGTH = BUILDER
+                .comment("Maximum wire length for Duo Connectors.")
+                .defineInRange("duo_connector_max_wire_length", 16, 1, 64);
+
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Electric Crusher")
+                .push("electric_crusher_specifics");
+
+        ELECTRIC_CRUSHER_MIN_OPERATING_VOLTAGE = BUILDER
+                .comment("Minimum voltage required for the Electric Crusher to start and continue operating (Volts).")
+                .defineInRange("electric_crusher_min_operating_voltage", 70.0, 1.0, 500.0);
+
+        ELECTRIC_CRUSHER_NOMINAL_OPERATING_CURRENT = BUILDER
+                .comment("Nominal operating current for the Electric Crusher under its typical designed load (Amps).")
+                .defineInRange("electric_crusher_nominal_operating_current", 8.0, 0.1, 50.0);
+
+        ELECTRIC_CRUSHER_MAX_SAFE_CURRENT = BUILDER
+                .comment("Maximum current the Electric Crusher can safely handle before risking damage or shutdown (Amps).")
+                .defineInRange("electric_crusher_max_safe_current", 20.0, 1.0, 100.0);
+
+        ELECTRIC_CRUSHER_DEFAULT_CRUSHING_TIME = BUILDER
+                .comment("Default time in ticks it takes for the Electric Crusher to process one item/recipe.")
+                .defineInRange("electric_crusher_default_crushing_time", 100, 20, 600);
+
+        ELECTRIC_CRUSHER_INTERNAL_RESISTANCE = BUILDER
+                .comment("Default internal resistance of the Electric Crusher (Ohms).")
+                .defineInRange("electric_crusher_internal_resistance", 10, 1, 100);
+
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Arc Furnace")
+                .push("arc_furnace_specifics");
+
+        ARC_FURNACE_MIN_OPERATING_VOLTAGE = BUILDER
+                .comment("Minimum voltage required for the Arc Furnace to start and continue operating (Volts).")
+                .defineInRange("arc_furnace_min_operating_voltage", 150.0, 10.0, 800.0);
+
+        ARC_FURNACE_NOMINAL_OPERATING_CURRENT = BUILDER
+                .comment("Nominal operating current for the Arc Furnace under its typical designed load (Amps).")
+                .defineInRange("arc_furnace_nominal_operating_current", 15.0, 0.1, 100.0);
+
+        ARC_FURNACE_MAX_SAFE_CURRENT = BUILDER
+                .comment("Maximum current the Arc Furnace can safely handle before risking damage or shutdown (Amps).")
+                .defineInRange("arc_furnace_max_safe_current", 40.0, 1.0, 200.0);
+
+        ARC_FURNACE_DEFAULT_SMELTING_TIME = BUILDER
+                .comment("Default time in ticks it takes for the Arc Furnace to process one item/recipe.")
+                .defineInRange("arc_furnace_default_smelting_time", 200, 20, 1200);
+
+        ARC_FURNACE_INTERNAL_RESISTANCE = BUILDER
+                .comment("Internal resistance of the Arc Furnace used by the block entity (Ohms).")
+                .defineInRange("arc_furnace_internal_resistance", 20, 1, 200);
+
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Refinery")
+                .push("refinery_specifics");
+
+        REFINERY_MIN_OPERATING_VOLTAGE = BUILDER
+                .comment("Minimum voltage required for the Refinery to start and continue operating (Volts).")
+                .defineInRange("refinery_min_operating_voltage", 120.0, 10.0, 700.0);
+
+        REFINERY_NOMINAL_OPERATING_CURRENT = BUILDER
+                .comment("Nominal operating current for the Refinery under its typical designed load (Amps).")
+                .defineInRange("refinery_nominal_operating_current", 12.0, 0.1, 80.0);
+
+        REFINERY_MAX_SAFE_CURRENT = BUILDER
+                .comment("Maximum current the Refinery can safely handle before risking damage or shutdown (Amps).")
+                .defineInRange("refinery_max_safe_current", 30.0, 1.0, 150.0);
+
+        REFINERY_DEFAULT_PROCESSING_TIME = BUILDER
+                .comment("Default time in ticks it takes for the Refinery to process one item/recipe.")
+                .defineInRange("refinery_default_processing_time", 150, 20, 1000);
+
+        REFINERY_INTERNAL_RESISTANCE = BUILDER
+                .comment("Internal resistance of the Refinery used by the block entity (Ohms).")
+                .defineInRange("refinery_internal_resistance", 15, 1, 150);
+
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Electric Lamp")
+                .push("electric_lamp_specifics");
+
+        ELECTRIC_LAMP_MIN_OPERATING_VOLTAGE = BUILDER
+                .comment("Minimum voltage required for the Electric Lamp to start and continue operating (Volts).")
+                .defineInRange("electric_lamp_min_operating_voltage", 24.0, 1.0, 100.0);
+
+        ELECTRIC_LAMP_NOMINAL_OPERATING_CURRENT = BUILDER
+                .comment("Nominal operating current for the Electric Lamp under its typical designed load (Amps).")
+                .defineInRange("electric_lamp_nominal_operating_current", 0.5, 0.01, 10.0); // Adjusted range for typical lamp
+
+        ELECTRIC_LAMP_MAX_SAFE_CURRENT = BUILDER
+                .comment("Maximum current the Electric Lamp can safely handle before risking damage or shutdown (Amps).")
+                .defineInRange("electric_lamp_max_safe_current", 2.0, 0.1, 20.0); // Adjusted range
+
+        ELECTRIC_LAMP_MIN_LIGHT_POWER_WATTS = BUILDER
+                .comment("Minimum power (in Watts) required for the lamp to produce any light.")
+                .defineInRange("electric_lamp_min_light_power_watts", 5.0, 0.1, 50.0);
+
+        ELECTRIC_LAMP_INTERNAL_RESISTANCE = BUILDER
+                .comment("Default internal resistance of the Electric Lamp (Ohms).")
+                .defineInRange("electric_lamp_internal_resistance", 25, 1, 200);
+
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Combustion Generator")
+                .push("combustion_generator_specifics");
+
+        COMBUSTION_GENERATOR_OUTPUT_VOLTAGE = BUILDER
+                .comment("Nominal output voltage of the Combustion Generator (Volts).")
+                .defineInRange("combustion_generator_output_voltage", 400.0, 10.0, 2000.0);
+
+        BUILDER.pop();
+    }
+
+    static {
+        BUILDER.comment("Specific operational parameters for the Solar Panel")
+                .push("solar_panel_specifics");
+
+        SOLAR_PANEL_OUTPUT_VOLTAGE = BUILDER
+                .comment("Nominal output voltage of the Solar Panel under optimal conditions (Volts).")
+                .defineInRange("solar_panel_output_voltage", 230.0, 5.0, 500.0);
+
+        BUILDER.pop();
+    }
 
     static final ModConfigSpec SPEC = BUILDER.build();
 
-    public static boolean logDirtBlock;
-    public static int magicNumber;
-    public static String magicNumberIntroduction;
-    public static Set<Item> items;
+    // Connector Settings
+    private static final ModConfigSpec.IntValue SMALL_CONNECTOR_MAX_WIRE_LENGTH;
+    private static final ModConfigSpec.IntValue LARGE_CONNECTOR_MAX_WIRE_LENGTH;
+    private static final ModConfigSpec.IntValue DUO_CONNECTOR_MAX_WIRE_LENGTH;
+    private static final ModConfigSpec.IntValue SMALL_CONNECTOR_CONNECTION_POINT_COUNT;
+    private static final ModConfigSpec.IntValue LARGE_CONNECTOR_CONNECTION_POINT_COUNT;
 
-    private static boolean validateItemName(final Object obj)
-    {
-        return obj instanceof String itemName && BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemName));
-    }
+    // Electric Crusher Specific Settings
+    private static final ModConfigSpec.DoubleValue ELECTRIC_CRUSHER_MIN_OPERATING_VOLTAGE;
+    private static final ModConfigSpec.DoubleValue ELECTRIC_CRUSHER_NOMINAL_OPERATING_CURRENT;
+    private static final ModConfigSpec.DoubleValue ELECTRIC_CRUSHER_MAX_SAFE_CURRENT;
+    private static final ModConfigSpec.IntValue ELECTRIC_CRUSHER_DEFAULT_CRUSHING_TIME;
+    private static final ModConfigSpec.IntValue ELECTRIC_CRUSHER_INTERNAL_RESISTANCE;
+
+    // Arc Furnace Specific Settings
+    private static final ModConfigSpec.DoubleValue ARC_FURNACE_MIN_OPERATING_VOLTAGE;
+    private static final ModConfigSpec.DoubleValue ARC_FURNACE_NOMINAL_OPERATING_CURRENT;
+    private static final ModConfigSpec.DoubleValue ARC_FURNACE_MAX_SAFE_CURRENT;
+    private static final ModConfigSpec.IntValue ARC_FURNACE_DEFAULT_SMELTING_TIME;
+    private static final ModConfigSpec.IntValue ARC_FURNACE_INTERNAL_RESISTANCE;
+
+    // Refinery Specific Settings
+    private static final ModConfigSpec.DoubleValue REFINERY_MIN_OPERATING_VOLTAGE;
+    private static final ModConfigSpec.DoubleValue REFINERY_NOMINAL_OPERATING_CURRENT;
+    private static final ModConfigSpec.DoubleValue REFINERY_MAX_SAFE_CURRENT;
+    private static final ModConfigSpec.IntValue REFINERY_DEFAULT_PROCESSING_TIME;
+    private static final ModConfigSpec.IntValue REFINERY_INTERNAL_RESISTANCE;
+
+    // Electric Lamp Specific Settings
+    private static final ModConfigSpec.DoubleValue ELECTRIC_LAMP_MIN_OPERATING_VOLTAGE;
+    private static final ModConfigSpec.DoubleValue ELECTRIC_LAMP_NOMINAL_OPERATING_CURRENT;
+    private static final ModConfigSpec.DoubleValue ELECTRIC_LAMP_MAX_SAFE_CURRENT;
+    private static final ModConfigSpec.DoubleValue ELECTRIC_LAMP_MIN_LIGHT_POWER_WATTS;
+    private static final ModConfigSpec.IntValue ELECTRIC_LAMP_INTERNAL_RESISTANCE;
+
+    // Combustion Generator Specific Settings
+    private static final ModConfigSpec.DoubleValue COMBUSTION_GENERATOR_OUTPUT_VOLTAGE;
+
+    // Solar Panel Specific Settings
+    private static final ModConfigSpec.DoubleValue SOLAR_PANEL_OUTPUT_VOLTAGE;
+
+    // --- Public Static Fields for Accessing Loaded Values ---
+    public static int smallConnectorMaxWireLength;
+    public static int largeConnectorMaxWireLength;
+    public static int duoConnectorMaxWireLength;
+    public static int smallConnectorConnectionPointCount;
+    public static int largeConnectorConnectionPointCount;
+
+    // Electric Crusher
+    public static double electricCrusherMinOperatingVoltage;
+    public static double electricCrusherNominalOperatingCurrent;
+    public static double electricCrusherMaxSafeCurrent;
+    public static int electricCrusherDefaultCrushingTime;
+    public static int electricCrusherInternalResistance;
+
+    // Arc Furnace
+    public static double arcFurnaceMinOperatingVoltage;
+    public static double arcFurnaceNominalOperatingCurrent;
+    public static double arcFurnaceMaxSafeCurrent;
+    public static int arcFurnaceDefaultSmeltingTime;
+    public static int arcFurnaceInternalResistance;
+
+    // Refinery
+    public static double refineryMinOperatingVoltage;
+    public static double refineryNominalOperatingCurrent;
+    public static double refineryMaxSafeCurrent;
+    public static int refineryDefaultProcessingTime;
+    public static int refineryInternalResistance;
+
+    // Electric Lamp
+    public static double electricLampMinOperatingVoltage;
+    public static double electricLampNominalOperatingCurrent;
+    public static double electricLampMaxSafeCurrent;
+    public static double electricLampMinLightPowerWatts;
+    public static int electricLampInternalResistance;
+
+    // Combustion Generator
+    public static double combustionGeneratorOutputVoltage;
+
+    // Solar Panel
+    public static double solarPanelOutputVoltage;
 
     @SubscribeEvent
     static void onLoad(final ModConfigEvent event)
     {
-        logDirtBlock = LOG_DIRT_BLOCK.get();
-        magicNumber = MAGIC_NUMBER.get();
-        magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
+        smallConnectorMaxWireLength = SMALL_CONNECTOR_MAX_WIRE_LENGTH.get();
+        largeConnectorMaxWireLength = LARGE_CONNECTOR_MAX_WIRE_LENGTH.get();
+        duoConnectorMaxWireLength = DUO_CONNECTOR_MAX_WIRE_LENGTH.get();
 
-        // convert the list of strings into a set of items
-        items = ITEM_STRINGS.get().stream()
-                .map(itemName -> BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemName)))
-                .collect(Collectors.toSet());
+        smallConnectorConnectionPointCount = SMALL_CONNECTOR_CONNECTION_POINT_COUNT.get();
+        largeConnectorConnectionPointCount = LARGE_CONNECTOR_CONNECTION_POINT_COUNT.get();
+
+        // Load Electric Crusher
+        electricCrusherMinOperatingVoltage = ELECTRIC_CRUSHER_MIN_OPERATING_VOLTAGE.get();
+        electricCrusherNominalOperatingCurrent = ELECTRIC_CRUSHER_NOMINAL_OPERATING_CURRENT.get();
+        electricCrusherMaxSafeCurrent = ELECTRIC_CRUSHER_MAX_SAFE_CURRENT.get();
+        electricCrusherDefaultCrushingTime = ELECTRIC_CRUSHER_DEFAULT_CRUSHING_TIME.get();
+        electricCrusherInternalResistance = ELECTRIC_CRUSHER_INTERNAL_RESISTANCE.get();
+
+        // Load Arc Furnace
+        arcFurnaceMinOperatingVoltage = ARC_FURNACE_MIN_OPERATING_VOLTAGE.get();
+        arcFurnaceNominalOperatingCurrent = ARC_FURNACE_NOMINAL_OPERATING_CURRENT.get();
+        arcFurnaceMaxSafeCurrent = ARC_FURNACE_MAX_SAFE_CURRENT.get();
+        arcFurnaceDefaultSmeltingTime = ARC_FURNACE_DEFAULT_SMELTING_TIME.get();
+        arcFurnaceInternalResistance = ARC_FURNACE_INTERNAL_RESISTANCE.get();
+
+        // Load Refinery
+        refineryMinOperatingVoltage = REFINERY_MIN_OPERATING_VOLTAGE.get();
+        refineryNominalOperatingCurrent = REFINERY_NOMINAL_OPERATING_CURRENT.get();
+        refineryMaxSafeCurrent = REFINERY_MAX_SAFE_CURRENT.get();
+        refineryDefaultProcessingTime = REFINERY_DEFAULT_PROCESSING_TIME.get();
+        refineryInternalResistance = REFINERY_INTERNAL_RESISTANCE.get();
+
+        // Load Electric Lamp
+        electricLampMinOperatingVoltage = ELECTRIC_LAMP_MIN_OPERATING_VOLTAGE.get();
+        electricLampNominalOperatingCurrent = ELECTRIC_LAMP_NOMINAL_OPERATING_CURRENT.get();
+        electricLampMaxSafeCurrent = ELECTRIC_LAMP_MAX_SAFE_CURRENT.get();
+        electricLampMinLightPowerWatts = ELECTRIC_LAMP_MIN_LIGHT_POWER_WATTS.get();
+        electricLampInternalResistance = ELECTRIC_LAMP_INTERNAL_RESISTANCE.get();
+
+        // Load Combustion Generator
+        combustionGeneratorOutputVoltage = COMBUSTION_GENERATOR_OUTPUT_VOLTAGE.get();
+
+        // Load Solar Panel
+        solarPanelOutputVoltage = SOLAR_PANEL_OUTPUT_VOLTAGE.get();
     }
 }

--- a/src/main/java/com/teamofpowersim/powersim/PowerSim.java
+++ b/src/main/java/com/teamofpowersim/powersim/PowerSim.java
@@ -16,14 +16,13 @@ import com.teamofpowersim.powersim.simulation.NgSpiceSimulator;
 import com.teamofpowersim.powersim.screen.refinery.RefineryScreen;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.neoforged.neoforge.client.event.RegisterMenuScreensEvent;
+import net.neoforged.neoforge.client.gui.ConfigurationScreen;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import org.slf4j.Logger;
 
 import com.mojang.logging.LogUtils;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.level.block.Blocks;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -34,7 +33,6 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 
 import java.io.IOException;
@@ -65,9 +63,8 @@ public class PowerSim {
         ModRecipes.register(modEventBus);
         ModDataComponents.register(modEventBus);
 
-        modEventBus.addListener(this::addCreative);
-
         modContainer.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
+        modContainer.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
@@ -77,30 +74,12 @@ public class PowerSim {
         } catch (IOException e) {
             throw new RuntimeException("Could not load ngspice native", e);
         }
-
-        LOGGER.info("HELLO FROM COMMON SETUP");
-
-        if (Config.logDirtBlock)
-            LOGGER.info("DIRT BLOCK >> {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
-
-        LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
-
-        Config.items.forEach(item -> LOGGER.info("ITEM >> {}", item.toString()));
     }
 
     private void setupRenderers(final FMLCommonSetupEvent event) {
         BlockEntityRenderers.register(ModBlockEntityTypes.SMALL_CONNECTOR_BE.get(), ConnectorRenderer::new);
         BlockEntityRenderers.register(ModBlockEntityTypes.LARGE_CONNECTOR_BE.get(), ConnectorRenderer::new);
         BlockEntityRenderers.register(ModBlockEntityTypes.DUO_CONNECTOR_BE.get(), ConnectorRenderer::new);
-    }
-
-    private void addCreative(BuildCreativeModeTabContentsEvent event) {
-        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) {
-            event.accept(ModBlocks.COPPER_WIRE);
-            event.accept(ModBlocks.ELECTRIC_CRUSHER);
-            event.accept(ModBlocks.ARC_FURNACE);
-            event.accept(ModBlocks.MOUNTING_PLATE);
-        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/teamofpowersim/powersim/block/connector/duo/DuoConnectorBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/connector/duo/DuoConnectorBlockEntity.java
@@ -1,5 +1,6 @@
 package com.teamofpowersim.powersim.block.connector.duo;
 
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
 import com.teamofpowersim.powersim.block.connector.AbstractConnectorBlock;
 import com.teamofpowersim.powersim.block.connector.AbstractConnectorBlockEntity;
@@ -37,7 +38,7 @@ public class DuoConnectorBlockEntity extends AbstractConnectorBlockEntity {
      * @param index The node index (0 or 1).
      * @return The TerminalType for that node. Returns TerminalType.None if index is invalid or property missing.
      */
-    @Nullable // Keep Nullable for consistency, though it should always return a value now
+    @Nullable
     @Override
     public ConnectorPolarity getTerminalType(int index) {
         BlockState state = this.getBlockState();
@@ -48,8 +49,6 @@ public class DuoConnectorBlockEntity extends AbstractConnectorBlockEntity {
                 return state.getValue(DuoConnectorBlock.TERMINAL_TYPE_1);
             }
         } catch (IllegalArgumentException e) {
-            // This might happen if the blockstate somehow doesn't have the property,
-            // though it should if createBlockStateDefinition is correct.
             System.err.println("Error getting TerminalType property for DuoConnector at " + worldPosition + ": " + e.getMessage());
         }
         // Fallback
@@ -63,12 +62,12 @@ public class DuoConnectorBlockEntity extends AbstractConnectorBlockEntity {
 
     @Override
     public int getMaxWireLength() {
-        return 16; // Or your desired value
+        return Config.duoConnectorMaxWireLength;
     }
 
     @Override
     public int getConnectionPointCount() {
-        return 2; // Still two connection points
+        return 2;
     }
 
     @Override

--- a/src/main/java/com/teamofpowersim/powersim/block/connector/large/LargeConnectorBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/connector/large/LargeConnectorBlockEntity.java
@@ -1,5 +1,6 @@
 package com.teamofpowersim.powersim.block.connector.large;
 
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
 import com.teamofpowersim.powersim.block.connector.AbstractConnectorBlock;
 import com.teamofpowersim.powersim.block.connector.AbstractConnectorBlockEntity;
@@ -35,12 +36,12 @@ public class LargeConnectorBlockEntity extends AbstractConnectorBlockEntity {
 
     @Override
     public int getMaxWireLength() {
-        return 16;
+        return Config.largeConnectorMaxWireLength;
     }
 
     @Override
     public int getConnectionPointCount() {
-        return 4;
+        return Config.largeConnectorConnectionPointCount;
     }
 
     @Override

--- a/src/main/java/com/teamofpowersim/powersim/block/connector/small/SmallConnectorBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/connector/small/SmallConnectorBlockEntity.java
@@ -1,5 +1,6 @@
 package com.teamofpowersim.powersim.block.connector.small;
 
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
 import com.teamofpowersim.powersim.block.connector.AbstractConnectorBlock;
 import com.teamofpowersim.powersim.block.connector.AbstractConnectorBlockEntity;
@@ -35,12 +36,12 @@ public class SmallConnectorBlockEntity extends AbstractConnectorBlockEntity {
 
     @Override
     public int getMaxWireLength() {
-        return 16;
+        return Config.smallConnectorMaxWireLength;
     }
 
     @Override
     public int getConnectionPointCount() {
-        return 4;
+        return Config.smallConnectorConnectionPointCount;
     }
 
     @Override

--- a/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/arc_furnace/ArcFurnaceBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/arc_furnace/ArcFurnaceBlockEntity.java
@@ -1,6 +1,7 @@
 package com.teamofpowersim.powersim.block.machine.consumer.arc_furnace;
 
 import com.mojang.logging.LogUtils;
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
 import com.teamofpowersim.powersim.block.machine.consumer.AbstractPowerConsumerBlockEntity;
 import com.teamofpowersim.powersim.recipe.ModRecipes;
@@ -57,13 +58,13 @@ public class ArcFurnaceBlockEntity extends AbstractPowerConsumerBlockEntity impl
     private static final String INTERNAL_RESISTANCE_KEY = "arc_furnace.internal_resistance";
 
     // Electrical Configuration
-    private static final double FURNACE_MIN_OPERATING_VOLTAGE = 100.0;
-    private static final double FURNACE_NOMINAL_OPERATING_CURRENT = 15.0;
-    private static final double FURNACE_MAX_SAFE_CURRENT = 50.0;
+    private static final double FURNACE_MIN_OPERATING_VOLTAGE = Config.arcFurnaceMinOperatingVoltage;
+    private static final double FURNACE_NOMINAL_OPERATING_CURRENT = Config.arcFurnaceNominalOperatingCurrent;
+    private static final double FURNACE_MAX_SAFE_CURRENT = Config.arcFurnaceMaxSafeCurrent;
 
     // Operational Parameters
-    private static final int DEFAULT_TOTAL_SMELTING_TIME = 80;
-    private static final int DEFAULT_INTERNAL_RESISTANCE = 25;
+    private static final int DEFAULT_TOTAL_SMELTING_TIME = Config.arcFurnaceDefaultSmeltingTime;
+    private static final int DEFAULT_INTERNAL_RESISTANCE = Config.arcFurnaceInternalResistance;
 
     private int heatLevel;
     private int heatTotalLevel = 7;
@@ -131,7 +132,7 @@ public class ArcFurnaceBlockEntity extends AbstractPowerConsumerBlockEntity impl
         double actualVoltage = getSimVoltage();
 
         if (Math.abs(actualCurrent) > getMaxSafeCurrent()) {
-            LOGGER.warn("Arc Furnace at {} OVERCURRENT! I: {:.2f}A > {:.2f}A. Destroying.", blockPos, actualCurrent, getMaxSafeCurrent());
+            LOGGER.warn("Arc Furnace at {} OVERCURRENT! I: {}A > {}A. Destroying.", blockPos, actualCurrent, getMaxSafeCurrent());
             level.destroyBlock(blockPos, true);
             return;
         }

--- a/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/crusher/ElectricCrusherBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/crusher/ElectricCrusherBlockEntity.java
@@ -1,6 +1,7 @@
 package com.teamofpowersim.powersim.block.machine.consumer.crusher;
 
 import com.mojang.logging.LogUtils;
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
 import com.teamofpowersim.powersim.block.machine.consumer.AbstractPowerConsumerBlockEntity;
 import com.teamofpowersim.powersim.recipe.ModRecipes;
@@ -54,12 +55,12 @@ public class ElectricCrusherBlockEntity extends AbstractPowerConsumerBlockEntity
     private static final String CRUSHING_TOTAL_TIME_KEY = "electric_crusher.crushing_total_time";
     private static final String INTERNAL_RESISTANCE_KEY = "electric_crusher.internal_resistance";
 
-    private static final double CRUSHER_MIN_OPERATING_VOLTAGE = 70.0;
-    private static final double CRUSHER_NOMINAL_OPERATING_CURRENT = 8.0;
-    private static final double CRUSHER_MAX_SAFE_CURRENT = 20.0;
+    private static final double CRUSHER_MIN_OPERATING_VOLTAGE = Config.electricCrusherMinOperatingVoltage;
+    private static final double CRUSHER_NOMINAL_OPERATING_CURRENT = Config.electricCrusherNominalOperatingCurrent;
+    private static final double CRUSHER_MAX_SAFE_CURRENT = Config.electricCrusherMaxSafeCurrent;
 
-    private static final int DEFAULT_TOTAL_CRUSHING_TIME = 100;
-    private static final int DEFAULT_INTERNAL_RESISTANCE = 25;
+    private static final int DEFAULT_TOTAL_CRUSHING_TIME = Config.electricCrusherDefaultCrushingTime;
+    private static final int DEFAULT_INTERNAL_RESISTANCE = Config.electricCrusherInternalResistance;
 
     private int crushingProgress;
     private int crushingTotalTime = DEFAULT_TOTAL_CRUSHING_TIME;
@@ -117,7 +118,7 @@ public class ElectricCrusherBlockEntity extends AbstractPowerConsumerBlockEntity
         // Overcurrent check
         double actualCurrent = getSimCurrent();
         if (Math.abs(actualCurrent) > getMaxSafeCurrent()) {
-            LOGGER.warn("Electric Crusher at {} OVERCURRENT! I: {:.2f}A > {:.2f}A. Destroying.", blockPos, actualCurrent, getMaxSafeCurrent());
+            LOGGER.warn("Electric Crusher at {} OVERCURRENT! I: {}A > {}A. Destroying.", blockPos, actualCurrent, getMaxSafeCurrent());
             level.destroyBlock(blockPos, true);
             return;
         }

--- a/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/lamp/ElectricLampBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/lamp/ElectricLampBlockEntity.java
@@ -1,30 +1,27 @@
 package com.teamofpowersim.powersim.block.machine.consumer.lamp;
 
 import com.mojang.logging.LogUtils;
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
 import com.teamofpowersim.powersim.block.machine.consumer.AbstractPowerConsumerBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 public class ElectricLampBlockEntity extends AbstractPowerConsumerBlockEntity {
     private static final Logger LOGGER = LogUtils.getLogger();
 
-    public static final double LAMP_MIN_OPERATING_VOLTAGE  = 24.0;
-    public static final double LAMP_NOMINAL_OPERATING_CURRENT = 8.0;
-    public static final double LAMP_MAX_SAFE_CURRENT          = 20.0;
-    public static final double LAMP_MIN_LIGHT_POWER_WATTS     = 5.0;
+    public static final double LAMP_MIN_OPERATING_VOLTAGE       = Config.electricLampMinOperatingVoltage;
+    public static final double LAMP_NOMINAL_OPERATING_CURRENT   = Config.electricLampNominalOperatingCurrent;
+    public static final double LAMP_MAX_SAFE_CURRENT            = Config.electricLampMaxSafeCurrent;
+    public static final double LAMP_MIN_LIGHT_POWER_WATTS       = Config.electricLampMinLightPowerWatts;
 
-    private static final String INTERNAL_RESISTANCE_KEY = "electric_lamp.internal_resistance";
-    private static final int DEFAULT_INTERNAL_RESISTANCE = 25;
+    private static final String INTERNAL_RESISTANCE_KEY         = "electric_lamp.internal_resistance";
+    private static final int DEFAULT_INTERNAL_RESISTANCE        = Config.electricLampInternalResistance;
 
     private int internalResistance = DEFAULT_INTERNAL_RESISTANCE;
 

--- a/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/refinery/RefineryBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/machine/consumer/refinery/RefineryBlockEntity.java
@@ -1,6 +1,7 @@
 package com.teamofpowersim.powersim.block.machine.consumer.refinery;
 
 import com.mojang.logging.LogUtils;
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
 import com.teamofpowersim.powersim.block.machine.consumer.AbstractPowerConsumerBlockEntity;
 import com.teamofpowersim.powersim.recipe.ModRecipes;
@@ -55,13 +56,13 @@ public class RefineryBlockEntity extends AbstractPowerConsumerBlockEntity implem
     private static final String INTERNAL_RESISTANCE_KEY = "refinery.internal_resistance";
 
     // Electrical Configuration
-    private static final double REFINERY_MIN_OPERATING_VOLTAGE = 90.0;
-    private static final double REFINERY_NOMINAL_OPERATING_CURRENT = 12.0;
-    private static final double REFINERY_MAX_SAFE_CURRENT = 25.0;
+    private static final double REFINERY_MIN_OPERATING_VOLTAGE = Config.refineryMinOperatingVoltage;
+    private static final double REFINERY_NOMINAL_OPERATING_CURRENT = Config.refineryNominalOperatingCurrent;
+    private static final double REFINERY_MAX_SAFE_CURRENT = Config.refineryMaxSafeCurrent;
 
     // Operational Parameters
-    private static final int DEFAULT_TOTAL_REFINING_TIME = 150;
-    private static final int DEFAULT_INTERNAL_RESISTANCE = 22;
+    private static final int DEFAULT_TOTAL_REFINING_TIME = Config.refineryDefaultProcessingTime;
+    private static final int DEFAULT_INTERNAL_RESISTANCE = Config.refineryInternalResistance;
 
     private int refiningProgress;
     private int refiningTotalTime = DEFAULT_TOTAL_REFINING_TIME;

--- a/src/main/java/com/teamofpowersim/powersim/block/machine/provider/combustion/CombustionGeneratorBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/machine/provider/combustion/CombustionGeneratorBlockEntity.java
@@ -1,6 +1,7 @@
 package com.teamofpowersim.powersim.block.machine.provider.combustion;
 
 import com.mojang.logging.LogUtils;
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.PowerSim;
 import com.teamofpowersim.powersim.block.IActiveVoltageProvider;
 import com.teamofpowersim.powersim.block.ModBlockEntityTypes;
@@ -51,7 +52,7 @@ public class CombustionGeneratorBlockEntity extends AbstractPowerProviderBlockEn
     private int litTime;
     private int litDuration;
     private final ContainerData data;
-    private final int nominalVoltage = 400;
+    private final int nominalVoltage = (int) Config.combustionGeneratorOutputVoltage; // TODO should be double
 
     public CombustionGeneratorBlockEntity(BlockPos pos, BlockState blockState) {
         super(ModBlockEntityTypes.COMBUSTION_GENERATOR_BE.get(), pos, blockState);

--- a/src/main/java/com/teamofpowersim/powersim/block/machine/provider/solarpanel/SolarPanelBlockEntity.java
+++ b/src/main/java/com/teamofpowersim/powersim/block/machine/provider/solarpanel/SolarPanelBlockEntity.java
@@ -1,5 +1,6 @@
 package com.teamofpowersim.powersim.block.machine.provider.solarpanel;
 
+import com.teamofpowersim.powersim.Config;
 import com.teamofpowersim.powersim.PowerSim; // For NetworkManager
 import com.teamofpowersim.powersim.block.IActiveVoltageProvider; // Import this
 import com.teamofpowersim.powersim.block.IVoltageConsumer;
@@ -16,7 +17,7 @@ import com.mojang.logging.LogUtils; // For logging
 public class SolarPanelBlockEntity extends AbstractPowerProviderBlockEntity implements IActiveVoltageProvider { // Implement IActiveVoltageProvider
     private static final Logger LOGGER = LogUtils.getLogger();
 
-    private final int nominalVoltage = 230; // Renamed for clarity
+    private final int nominalVoltage = (int) Config.solarPanelOutputVoltage; // TODO should be double
     private boolean currentActiveState = false; // Cache the active state to detect changes
 
     public SolarPanelBlockEntity(BlockPos pos, BlockState blockState) {

--- a/src/main/java/com/teamofpowersim/powersim/event/ClientEvents.java
+++ b/src/main/java/com/teamofpowersim/powersim/event/ClientEvents.java
@@ -1,7 +1,6 @@
 package com.teamofpowersim.powersim.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.logging.LogUtils;
 import com.teamofpowersim.powersim.PowerSim;
 import com.teamofpowersim.powersim.block.ModBlocks;
 import com.teamofpowersim.powersim.item.ModItems;
@@ -18,8 +17,6 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
-import org.checkerframework.checker.units.qual.C;
-import org.slf4j.Logger;
 
 @EventBusSubscriber(Dist.CLIENT)
 public class ClientEvents {

--- a/src/main/resources/assets/powersim/lang/en_us.json
+++ b/src/main/resources/assets/powersim/lang/en_us.json
@@ -66,6 +66,50 @@
   "statusbar.powersim.connector_set": "Connector terminal mode toggled",
 
   "statusbar.powersim.resistor_value": "Resistance: %s Ω",
-  "statusbar.powersim.resistor_set": "Resistance set to %s Ω"
+  "statusbar.powersim.resistor_set": "Resistance set to %s Ω",
 
+  "powersim.configuration.small_connector_specifics": "Small Connector Configuration",
+  "powersim.configuration.small_connector_max_wire_length": "Max Wire Length",
+  "powersim.configuration.small_connector_connection_point_count": "Connection Points",
+
+  "powersim.configuration.large_connector_specifics": "Large Connector Configuration",
+  "powersim.configuration.large_connector_max_wire_length": "Max Wire Length",
+  "powersim.configuration.large_connector_connection_point_count": "Connection Points",
+
+  "powersim.configuration.duo_connector_specifics": "Duo Connector Configuration",
+  "powersim.configuration.duo_connector_max_wire_length": "Max Wire Length",
+
+  "powersim.configuration.electric_crusher_specifics": "Crusher Configuration",
+  "powersim.configuration.electric_crusher_min_operating_voltage": "Min Operating Voltage (V)",
+  "powersim.configuration.electric_crusher_nominal_operating_current": "Nominal Operating Current (A)",
+  "powersim.configuration.electric_crusher_max_safe_current": "Max Safe Current (A)",
+  "powersim.configuration.electric_crusher_default_crushing_time": "Default Crushing Time (ticks)",
+  "powersim.configuration.electric_crusher_internal_resistance": "Internal Resistance (Ω)",
+
+  "powersim.configuration.arc_furnace_specifics": "Arc Furnace Configuration",
+  "powersim.configuration.arc_furnace_min_operating_voltage": "Min Operating Voltage (V)",
+  "powersim.configuration.arc_furnace_nominal_operating_current": "Nominal Operating Current (A)",
+  "powersim.configuration.arc_furnace_max_safe_current": "Max Safe Current (A)",
+  "powersim.configuration.arc_furnace_default_smelting_time": "Default Smelting Time (ticks)",
+  "powersim.configuration.arc_furnace_internal_resistance": "Internal Resistance (Ω)",
+
+  "powersim.configuration.refinery_specifics": "Refinery Configuration",
+  "powersim.configuration.refinery_min_operating_voltage": "Min Operating Voltage (V)",
+  "powersim.configuration.refinery_nominal_operating_current": "Nominal Operating Current (A)",
+  "powersim.configuration.refinery_max_safe_current": "Max Safe Current (A)",
+  "powersim.configuration.refinery_default_processing_time": "Default Processing Time (ticks)",
+  "powersim.configuration.refinery_internal_resistance": "Internal Resistance (Ω)",
+
+  "powersim.configuration.electric_lamp_specifics": "Electric Lamp Configuration",
+  "powersim.configuration.electric_lamp_min_operating_voltage": "Min Operating Voltage (V)",
+  "powersim.configuration.electric_lamp_nominal_operating_current": "Nominal Operating Current (A)",
+  "powersim.configuration.electric_lamp_max_safe_current": "Max Safe Current (A)",
+  "powersim.configuration.electric_lamp_min_light_power_watts": "Min Power for Light (W)",
+  "powersim.configuration.electric_lamp_internal_resistance": "Internal Resistance (Ω)",
+
+  "powersim.configuration.combustion_generator_specifics": "Combustion Generator Configuration",
+  "powersim.configuration.combustion_generator_output_voltage": "Nominal Output Voltage (V)",
+
+  "powersim.configuration.solar_panel_specifics": "Solar Panel Configuration",
+  "powersim.configuration.solar_panel_output_voltage": "Nominal Output Voltage (V)"
 }


### PR DESCRIPTION
This commit introduces a major refactor of how machine and connector parameters are managed, moving them from hardcoded values to a centralized and user-configurable system via `Config.java`.

Key changes include:

- **Centralized Configuration (`Config.java`):**
    - Added specific configuration groups and values for: - Small, Large, and Duo Connectors (max wire length, connection points) - Electric Crusher (min/nominal/max voltage/current, processing time, resistance) - Arc Furnace (min/nominal/max voltage/current, processing time, resistance) - Refinery (min/nominal/max voltage/current, processing time, resistance) - Electric Lamp (min/nominal/max voltage/current, min power for light, resistance) - Combustion Generator (nominal output voltage) - Solar Panel (nominal output voltage)
    - Config keys now consistently use underscores (e.g., `electric_crusher_min_operating_voltage`).
    - The `onLoad` method has been updated to correctly load all new values.

- **Block Entity Updates:**
    - `SmallConnectorBlockEntity`, `LargeConnectorBlockEntity`, and `DuoConnectorBlockEntity` now fetch their `maxWireLength` and `connectionPointCount` (where applicable) from `Config.java`.
    - `ElectricCrusherBlockEntity` and `ElectricLampBlockEntity` have been refactored to use constants derived directly from `Config.java` for their operational parameters, removing previous hardcoded static final fields.
    - NBT loading in these machine block entities now correctly uses the new config values as defaults if NBT data is missing.

- **Localization (`en_us.json`):**
    - Added comprehensive English (US) translations for all new configuration options.
    - Translations follow the pattern `powersim.configuration.group_name.setting_name` for clarity and consistency with the config file structure.
    - Added group title translations (e.g., `"powersim.configuration.electric_crusher_specifics": "Crusher Configuration"`).

These changes significantly improve the mod's flexibility and maintainability, allowing for easier balancing and customization by users. Closes #86 